### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # DevRev MCP server
+[![smithery badge](https://smithery.ai/badge/devrev-mcp)](https://smithery.ai/server/devrev-mcp)
 
 ## Overview
 
@@ -61,3 +62,4 @@ On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
   }
   ```
 </details>
+


### PR DESCRIPTION
This PR makes the following change to the README:

1. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/devrev-mcp

Let me know if any tweaks have to be made!